### PR TITLE
WIP: Key Space Preallocation

### DIFF
--- a/spark/src/main/scala/geotrellis/spark/KeyBounds.scala
+++ b/spark/src/main/scala/geotrellis/spark/KeyBounds.scala
@@ -22,7 +22,7 @@ object KeyBounds {
       val boundable = implicitly[Boundable[K]]
       seq
         .map{ kb => boundable.includes(key, kb) }
-        .foldLeft(false)(_ || _)    
+        .foldLeft(false)(_ || _)
     }
   }
 

--- a/spark/src/main/scala/geotrellis/spark/SpatialKey.scala
+++ b/spark/src/main/scala/geotrellis/spark/SpatialKey.scala
@@ -41,7 +41,7 @@ object SpatialKey {
   implicit object Boundable extends Boundable[SpatialKey] {
     def minBound(a: SpatialKey, b: SpatialKey) = {
       SpatialKey(math.min(a.col, b.col), math.min(a.row, b.row))
-    }    
+    }
     def maxBound(a: SpatialKey, b: SpatialKey) = {
       SpatialKey(math.max(a.col, b.col), math.max(a.row, b.row))
     }

--- a/spark/src/main/scala/geotrellis/spark/io/SparkLayerCopier.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/SparkLayerCopier.scala
@@ -11,7 +11,7 @@ import scala.reflect._
 abstract class SparkLayerCopier[Header: JsonFormat, K: Boundable: JsonFormat: ClassTag, V: ClassTag, M: JsonFormat](
   val attributeStore: AttributeStore[JsonFormat],
   layerReader: FilteringLayerReader[LayerId, K, M, RDD[(K, V)] with Metadata[M]],
-  layerWriter: Writer[LayerId, RDD[(K, V)] with Metadata[M], K]
+  layerWriter: Writer[LayerId, K, RDD[(K, V)] with Metadata[M]]
 ) extends LayerCopier[LayerId] {
 
   def headerUpdate(id: LayerId, header: Header): Header

--- a/spark/src/main/scala/geotrellis/spark/io/SparkLayerCopier.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/SparkLayerCopier.scala
@@ -11,7 +11,7 @@ import scala.reflect._
 abstract class SparkLayerCopier[Header: JsonFormat, K: Boundable: JsonFormat: ClassTag, V: ClassTag, M: JsonFormat](
   val attributeStore: AttributeStore[JsonFormat],
   layerReader: FilteringLayerReader[LayerId, K, M, RDD[(K, V)] with Metadata[M]],
-  layerWriter: Writer[LayerId, RDD[(K, V)] with Metadata[M]]
+  layerWriter: Writer[LayerId, RDD[(K, V)] with Metadata[M], K]
 ) extends LayerCopier[LayerId] {
 
   def headerUpdate(id: LayerId, header: Header): Header

--- a/spark/src/main/scala/geotrellis/spark/io/Writer.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/Writer.scala
@@ -1,6 +1,10 @@
 package geotrellis.spark.io
 
-trait Writer[K, V] extends ((K,V) => Unit) {
-  def write(key: K, value: V): Unit
-  def apply(key: K, value: V): Unit = write(key, value)
+import geotrellis.spark.KeyBounds
+
+
+trait Writer[K, V, J] extends ((K,V) => Unit) {
+  def write(key: K, value: V, kb: Option[KeyBounds[J]]): Unit
+  def write(key: K, value: V): Unit = write(key, value, None)
+  def apply(key: K, value: V): Unit = write(key, value, None)
 }

--- a/spark/src/main/scala/geotrellis/spark/io/Writer.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/Writer.scala
@@ -3,7 +3,7 @@ package geotrellis.spark.io
 import geotrellis.spark.KeyBounds
 
 
-trait Writer[K, V, J] extends ((K,V) => Unit) {
+trait Writer[K, J, V] extends ((K,V) => Unit) {
   def write(key: K, value: V, kb: Option[KeyBounds[J]]): Unit
   def write(key: K, value: V): Unit = write(key, value, None)
   def apply(key: K, value: V): Unit = write(key, value, None)

--- a/spark/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerWriter.scala
@@ -17,9 +17,9 @@ class AccumuloLayerWriter[K: Boundable: JsonFormat: ClassTag, V: ClassTag, M: Js
     rddWriter: BaseAccumuloRDDWriter[K, V],
     keyIndexMethod: KeyIndexMethod[K],
     table: String)
-  extends Writer[LayerId, RDD[(K, V)] with Metadata[M]] {
+  extends Writer[LayerId, RDD[(K, V)] with Metadata[M], K] {
 
-  def write(id: LayerId, rdd: RDD[(K, V)] with Metadata[M]): Unit = {
+  def write(id: LayerId, rdd: RDD[(K, V)] with Metadata[M], kb: Option[KeyBounds[K]]): Unit = {
     val header =
       AccumuloLayerHeader(
         keyClass = classTag[K].toString(),
@@ -27,7 +27,7 @@ class AccumuloLayerWriter[K: Boundable: JsonFormat: ClassTag, V: ClassTag, M: Js
         tileTable = table
       )
     val metaData = rdd.metadata
-    val keyBounds = implicitly[Boundable[K]].getKeyBounds(rdd)
+    val keyBounds = kb.getOrElse(implicitly[Boundable[K]].getKeyBounds(rdd))
     val keyIndex = keyIndexMethod.createIndex(keyBounds)
     val getRowId = (key: K) => index2RowId(keyIndex.toIndex(key))
 

--- a/spark/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/accumulo/AccumuloLayerWriter.scala
@@ -17,7 +17,7 @@ class AccumuloLayerWriter[K: Boundable: JsonFormat: ClassTag, V: ClassTag, M: Js
     rddWriter: BaseAccumuloRDDWriter[K, V],
     keyIndexMethod: KeyIndexMethod[K],
     table: String)
-  extends Writer[LayerId, RDD[(K, V)] with Metadata[M], K] {
+  extends Writer[LayerId, K, RDD[(K, V)] with Metadata[M]] {
 
   def write(id: LayerId, rdd: RDD[(K, V)] with Metadata[M], kb: Option[KeyBounds[K]]): Unit = {
     val header =

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileLayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileLayerWriter.scala
@@ -41,7 +41,7 @@ class FileLayerWriter[K: Boundable: JsonFormat: ClassTag, V: ClassTag, M: JsonFo
     catalogPath: String,
     clobber: Boolean = true,
     oneToOne: Boolean = false
-) extends Writer[LayerId, RDD[(K, V)] with Metadata[M], K] with LazyLogging {
+) extends Writer[LayerId, K, RDD[(K, V)] with Metadata[M]] with LazyLogging {
 
   def write(layerId: LayerId, rdd: RDD[(K, V)] with Metadata[M], kb: Option[KeyBounds[K]]) = {
     val catalogPathFile = new File(catalogPath)

--- a/spark/src/main/scala/geotrellis/spark/io/file/FileLayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/file/FileLayerWriter.scala
@@ -27,7 +27,7 @@ import java.io.File
   * @tparam K                Type of RDD Key (ex: SpatialKey)
   * @tparam V                Type of RDD Value (ex: Tile or MultiBandTile )
   * @tparam M                Type of Metadata associated with the RDD[(K,V)]
-  * 
+  *
   * @param catalogPath  The root directory of this catalog.
   * @param keyPrefix         File prefix to write the raster to
   * @param keyIndexMethod    Method used to convert RDD keys to SFC indexes
@@ -50,7 +50,7 @@ class FileLayerWriter[K: Boundable: JsonFormat: ClassTag, V: ClassTag, M: JsonFo
 
     val path = LayerPath(layerId)
     val metadata = rdd.metadata
-    val header = 
+    val header =
       FileLayerHeader(
         keyClass = classTag[K].toString(),
         valueClass = classTag[K].toString(),

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopLayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopLayerWriter.scala
@@ -19,7 +19,7 @@ class HadoopLayerWriter[K: Boundable: JsonFormat: ClassTag, V: ClassTag, M: Json
   val attributeStore: AttributeStore[JsonFormat],
   rddWriter: HadoopRDDWriter[K, V],
   keyIndexMethod: KeyIndexMethod[K])
-  extends Writer[LayerId, RDD[(K, V)] with Metadata[M], K] {
+  extends Writer[LayerId, K, RDD[(K, V)] with Metadata[M]] {
 
   def write(id: LayerId, rdd: RDD[(K, V)] with Metadata[M], kb: Option[KeyBounds[K]]): Unit = {
     implicit val sc = rdd.sparkContext

--- a/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopLayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/hadoop/HadoopLayerWriter.scala
@@ -19,9 +19,9 @@ class HadoopLayerWriter[K: Boundable: JsonFormat: ClassTag, V: ClassTag, M: Json
   val attributeStore: AttributeStore[JsonFormat],
   rddWriter: HadoopRDDWriter[K, V],
   keyIndexMethod: KeyIndexMethod[K])
-  extends Writer[LayerId, RDD[(K, V)] with Metadata[M]] {
+  extends Writer[LayerId, RDD[(K, V)] with Metadata[M], K] {
 
-  def write(id: LayerId, rdd: RDD[(K, V)] with Metadata[M]): Unit = {
+  def write(id: LayerId, rdd: RDD[(K, V)] with Metadata[M], kb: Option[KeyBounds[K]]): Unit = {
     implicit val sc = rdd.sparkContext
 
     val layerPath = new Path(rootPath,  s"${id.name}/${id.zoom}")
@@ -33,7 +33,7 @@ class HadoopLayerWriter[K: Boundable: JsonFormat: ClassTag, V: ClassTag, M: Json
         path = layerPath
       )
     val metaData = rdd.metadata
-    val keyBounds = implicitly[Boundable[K]].getKeyBounds(rdd)
+    val keyBounds = kb.getOrElse(implicitly[Boundable[K]].getKeyBounds(rdd))
     val keyIndex = keyIndexMethod.createIndex(keyBounds)
 
     try {

--- a/spark/src/main/scala/geotrellis/spark/io/index/HilbertKeyIndexMethod.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/index/HilbertKeyIndexMethod.scala
@@ -12,8 +12,8 @@ object HilbertKeyIndexMethod extends HilbertKeyIndexMethod {
   implicit def spatialKeyIndexIndex(m: HilbertKeyIndexMethod): KeyIndexMethod[SpatialKey] =
     new KeyIndexMethod[SpatialKey] {
       def createIndex(keyBounds: KeyBounds[SpatialKey]): KeyIndex[SpatialKey] = {
-        val xResolution = resolution(keyBounds.maxKey.row - keyBounds.minKey.row)
-        val yResolution = resolution(keyBounds.maxKey.col - keyBounds.minKey.col)
+        val xResolution = resolution(keyBounds.maxKey.col - keyBounds.minKey.col)
+        val yResolution = resolution(keyBounds.maxKey.row - keyBounds.minKey.row)
         HilbertSpatialKeyIndex(keyBounds, xResolution, yResolution)
       }
     }
@@ -21,9 +21,8 @@ object HilbertKeyIndexMethod extends HilbertKeyIndexMethod {
   def apply(temporalResolution: Int): KeyIndexMethod[SpaceTimeKey] =
     new KeyIndexMethod[SpaceTimeKey] {
       def createIndex(keyBounds: KeyBounds[SpaceTimeKey]): KeyIndex[SpaceTimeKey] = {
-        val xResolution = resolution(keyBounds.maxKey.row - keyBounds.minKey.row)
-        val yResolution = resolution(keyBounds.maxKey.col - keyBounds.minKey.col)
-
+        val xResolution = resolution(keyBounds.maxKey.col - keyBounds.minKey.col)
+        val yResolution = resolution(keyBounds.maxKey.row - keyBounds.minKey.row)
         HilbertSpaceTimeKeyIndex(keyBounds, xResolution, yResolution, temporalResolution)
       }
     }
@@ -36,8 +35,8 @@ object HilbertKeyIndexMethod extends HilbertKeyIndexMethod {
           val maxKey = keyBounds.maxKey
           KeyBounds[SpaceTimeKey](SpaceTimeKey(minKey.col, minKey.row, minDate), SpaceTimeKey(maxKey.col, maxKey.row, maxDate))
         }
-        val xResolution = resolution(keyBounds.maxKey.row - keyBounds.minKey.row)
-        val yResolution = resolution(keyBounds.maxKey.col - keyBounds.minKey.col)
+        val xResolution = resolution(keyBounds.maxKey.col - keyBounds.minKey.col)
+        val yResolution = resolution(keyBounds.maxKey.row - keyBounds.minKey.row)
         HilbertSpaceTimeKeyIndex(adjustedKeyBounds, xResolution, yResolution, temporalResolution)
       }
     }

--- a/spark/src/main/scala/geotrellis/spark/io/index/KeyIndex.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/index/KeyIndex.scala
@@ -31,7 +31,7 @@ trait KeyIndex[K] extends Serializable {
 
 trait KeyIndexMethod[K] extends Serializable {
   /** Helper method to get the resolution of a dimension. Takes the ceiling. */
-  def resolution(length: Double): Int = math.ceil(scala.math.log(length) / scala.math.log(2)).toInt
+  def resolution(length: Double): Int = math.ceil(scala.math.log(length) / scala.math.log(2)).toInt + 1
 
   def createIndex(keyBounds: KeyBounds[K]): KeyIndex[K]
 }

--- a/spark/src/main/scala/geotrellis/spark/io/index/hilbert/HilbertSpaceTimeKeyIndex.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/index/hilbert/HilbertSpaceTimeKeyIndex.scala
@@ -40,28 +40,28 @@ class HilbertSpaceTimeKeyIndex(
   val startMillis = keyBounds.minKey.temporalKey.time.getMillis
   val timeWidth = keyBounds.maxKey.temporalKey.time.getMillis - startMillis
   val temporalBinCount = math.pow(2, temporalResolution)
- 
+
   @transient lazy val chc = {
     val dimensionSpec =
-      new MultiDimensionalSpec( 
+      new MultiDimensionalSpec(
         List(
           math.pow(2, xResolution).toInt,
           math.pow(2, yResolution).toInt,
           math.pow(2, temporalResolution).toInt
-        ).map(new java.lang.Integer(_)) 
+        ).map(new java.lang.Integer(_))
       )
 
     new CompactHilbertCurve(dimensionSpec)
   }
 
   def binTime(key: SpaceTimeKey): Long = {
-    // index requires right bound to be exclusive but KeyBounds do not, fake that.      
+    // index requires right bound to be exclusive but KeyBounds do not, fake that.
     val bin = (((key.temporalKey.time.getMillis - startMillis) * temporalBinCount) / timeWidth)
     (if (bin == temporalBinCount) bin - 1  else bin).toLong
   }
 
   def toIndex(key: SpaceTimeKey): Long = {
-    val bitVectors = 
+    val bitVectors =
       Array(
         BitVectorFactories.OPTIMAL.apply(xResolution),
         BitVectorFactories.OPTIMAL.apply(yResolution),
@@ -88,7 +88,7 @@ class HilbertSpaceTimeKeyIndex(
         LongRange.of(binTime(keyRange._1), binTime(keyRange._2) + 1)
       )
 
-    val  regionInspector: RegionInspector[LongRange, LongContent] = 
+    val  regionInspector: RegionInspector[LongRange, LongContent] =
       SimpleRegionInspector.create(
         List(ranges),
         new LongContent(1),
@@ -97,10 +97,10 @@ class HilbertSpaceTimeKeyIndex(
         new LongContent(0L)
       )
 
-    val combiner = 
+    val combiner =
       new PlainFilterCombiner[LongRange, java.lang.Long, LongContent, LongRange](LongRange.of(0, 1));
 
-    val queryBuilder = 
+    val queryBuilder =
       BacktrackingQueryBuilder.create(
         regionInspector,
         combiner,

--- a/spark/src/main/scala/geotrellis/spark/io/s3/S3LayerWriter.scala
+++ b/spark/src/main/scala/geotrellis/spark/io/s3/S3LayerWriter.scala
@@ -36,7 +36,7 @@ class S3LayerWriter[K: Boundable: JsonFormat: ClassTag, V: ClassTag, M: JsonForm
     keyPrefix: String,
     clobber: Boolean = true,
     oneToOne: Boolean = false)
-  extends Writer[LayerId, RDD[(K, V)] with Metadata[M], K] with LazyLogging {
+  extends Writer[LayerId, K, RDD[(K, V)] with Metadata[M]] with LazyLogging {
 
   def getS3Client: () => S3Client = () => S3Client.default
 

--- a/spark/src/test/scala/geotrellis/spark/TestEnvironment.scala
+++ b/spark/src/test/scala/geotrellis/spark/TestEnvironment.scala
@@ -1,12 +1,12 @@
 /*
  * Copyright (c) 2014 DigitalGlobe.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -93,7 +93,7 @@ trait TestEnvironment extends BeforeAndAfterAll { self: Suite =>
   }
 
 
-  /* 
+  /*
    * Makes directory given a path. The parent directory is expected to exist
    * e.g., to make directory bar under /tmp/foo, call mkdir(new Path("/tmp/foo/bar"))
    * The parent directory is assumed to exist
@@ -101,9 +101,9 @@ trait TestEnvironment extends BeforeAndAfterAll { self: Suite =>
   def mkdir(dir: Path): Unit = {
    val handle = new File(dir.toUri())
     if (!handle.exists)
-      handle.mkdirs()    
+      handle.mkdirs()
   }
-  
+
   def clearTestDirectory() = FileUtil.fullyDelete(new File(outputLocal.toUri()))
 
   // clean up the test directory after the test
@@ -112,7 +112,7 @@ trait TestEnvironment extends BeforeAndAfterAll { self: Suite =>
     FileUtil.fullyDelete(new File(outputLocal.toUri()))
     sc.stop()
   }
- 
+
   // root directory name on both local file system and hdfs for all tests
   private final val outputHome = "testFiles"
 

--- a/spark/src/test/scala/geotrellis/spark/io/PersistenceSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/PersistenceSpec.scala
@@ -9,7 +9,7 @@ import scala.reflect._
 
 abstract class PersistenceSpec[K: Boundable: ClassTag, V: ClassTag, M] extends FunSpec with Matchers {
   type TestReader = FilteringLayerReader[LayerId, K, M, RDD[(K, V)] with Metadata[M]]
-  type TestWriter = Writer[LayerId, RDD[(K, V)] with Metadata[M], K]
+  type TestWriter = Writer[LayerId, K, RDD[(K, V)] with Metadata[M]]
   type TestUpdater = LayerUpdater[LayerId, K, V, M]
   type TestDeleter = LayerDeleter[LayerId]
   type TestCopier = LayerCopier[LayerId]

--- a/spark/src/test/scala/geotrellis/spark/io/PersistenceSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/PersistenceSpec.scala
@@ -104,7 +104,7 @@ abstract class PersistenceSpec[K: ClassTag, V: ClassTag, M] extends FunSpec with
     mover.move(movedLayerId, layerId)
   }
 
-  it("should not reindex a layer which doesn't exists") {
+  it("should not reindex a layer which doesn't exist") {
     intercept[LayerNotFoundError] {
       reindexer.reindex(movedLayerId)
     }

--- a/spark/src/test/scala/geotrellis/spark/io/PersistenceSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/PersistenceSpec.scala
@@ -9,7 +9,7 @@ import scala.reflect._
 
 abstract class PersistenceSpec[K: ClassTag, V: ClassTag, M] extends FunSpec with Matchers {
   type TestReader = FilteringLayerReader[LayerId, K, M, RDD[(K, V)] with Metadata[M]]
-  type TestWriter = Writer[LayerId, RDD[(K, V)] with Metadata[M]]
+  type TestWriter = Writer[LayerId, RDD[(K, V)] with Metadata[M], K]
   type TestUpdater = LayerUpdater[LayerId, K, V, M]
   type TestDeleter = LayerDeleter[LayerId]
   type TestCopier = LayerCopier[LayerId]

--- a/spark/src/test/scala/geotrellis/spark/io/PersistenceSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/PersistenceSpec.scala
@@ -7,7 +7,7 @@ import spray.json._
 import spray.json.DefaultJsonProtocol._
 import scala.reflect._
 
-abstract class PersistenceSpec[K: ClassTag, V: ClassTag, M] extends FunSpec with Matchers {
+abstract class PersistenceSpec[K: Boundable: ClassTag, V: ClassTag, M] extends FunSpec with Matchers {
   type TestReader = FilteringLayerReader[LayerId, K, M, RDD[(K, V)] with Metadata[M]]
   type TestWriter = Writer[LayerId, RDD[(K, V)] with Metadata[M], K]
   type TestUpdater = LayerUpdater[LayerId, K, V, M]
@@ -27,6 +27,7 @@ abstract class PersistenceSpec[K: ClassTag, V: ClassTag, M] extends FunSpec with
   def tiles: TestTileReader
 
   val layerId = LayerId("sample-" + this.getClass.getName, 1)
+  val preallocLayerId = LayerId("preallocSample-" + this.getClass.getName, 1)
   val deleteLayerId = LayerId("deleteSample-" + this.getClass.getName, 1) // second layer to avoid data race
   val copiedLayerId = LayerId("copySample-" + this.getClass.getName, 1)
   val movedLayerId = LayerId("moveSample-" + this.getClass.getName, 1)

--- a/spark/src/test/scala/geotrellis/spark/io/accumulo/AccumuloSpaceTimeAlternativeSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/accumulo/AccumuloSpaceTimeAlternativeSpec.scala
@@ -9,7 +9,7 @@ import geotrellis.spark.io._
 import geotrellis.spark.io.json._
 import geotrellis.spark.io.avro.codecs._
 
-class AccumuloSpaceTimeAlternativeSpec 
+class AccumuloSpaceTimeAlternativeSpec
     extends PersistenceSpec[SpaceTimeKey, Tile, RasterMetaData]
     with TestEnvironment
     with TestFiles

--- a/spark/src/test/scala/geotrellis/spark/io/index/hilbert/HilbertSpaceTimeKeyIndexSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/index/hilbert/HilbertSpaceTimeKeyIndexSpec.scala
@@ -14,26 +14,26 @@ class HilbertSpaceTimeKeyIndexSpec extends FunSpec with Matchers{
 
     it("indexes col, row, and time"){
       val hst = HilbertSpaceTimeKeyIndex(SpaceTimeKey(0,0,y2k), SpaceTimeKey(0,0,y2k.plusMillis(upperBound)),4 , 4)
-      val keys = 
+      val keys =
         for(col <- 0 until upperBound;
              row <- 0 until upperBound;
                 t <- 0 until upperBound) yield {
           hst.toIndex(SpaceTimeKey(col,row,y2k.plusMillis(t)))
-        } 
+        }
 
       keys.distinct.size should be (upperBound * upperBound * upperBound)
       keys.min should be (0)
       keys.max should be (upperBound * upperBound * upperBound - 1)
     }
-     
+
 
     it("generates hand indexes you can hand check 2x2x2"){
-     val hilbert = HilbertSpaceTimeKeyIndex(SpaceTimeKey(0,0,y2k), SpaceTimeKey(2,2,y2k.plusMillis(1)),1,1) 
+     val hilbert = HilbertSpaceTimeKeyIndex(SpaceTimeKey(0,0,y2k), SpaceTimeKey(2,2,y2k.plusMillis(1)),1,1)
      val idx = List[SpaceTimeKey](SpaceTimeKey(0,0,y2k), SpaceTimeKey(0,1,y2k),
                                   SpaceTimeKey(1,1,y2k), SpaceTimeKey(1,0,y2k),
                                   SpaceTimeKey(1,0,y2k.plusMillis(1)), SpaceTimeKey(1,1,y2k.plusMillis(1)),
                                   SpaceTimeKey(0,1,y2k.plusMillis(1)), SpaceTimeKey(0,0,y2k.plusMillis(1)))
-     
+
      for(i<-0 to 7 ){
        hilbert.toIndex(idx(i)) should be (i)
      }
@@ -43,7 +43,7 @@ class HilbertSpaceTimeKeyIndexSpec extends FunSpec with Matchers{
       val t1 = y2k
       val t2 = y2k.plusMillis(1)
 
-      //hand checked examples for a 2x2x2 
+      //hand checked examples for a 2x2x2
       // note: The col/row of the end key does not matter here, eh ?
       val hilbert = HilbertSpaceTimeKeyIndex(SpaceTimeKey(0,0,t1), SpaceTimeKey(1,1,t2), 1, 1)
 
@@ -77,6 +77,6 @@ class HilbertSpaceTimeKeyIndexSpec extends FunSpec with Matchers{
       idx = hilbert.indexRanges((SpaceTimeKey(0,1,t1), SpaceTimeKey(1,1,t2)))
       idx.length should be (2)
       idx.toSet should be (Set(1->2, 5->6))
-    } 
+    }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/io/index/hilbert/HilbertSpaceTimeKeyIndexSpec.scala
+++ b/spark/src/test/scala/geotrellis/spark/io/index/hilbert/HilbertSpaceTimeKeyIndexSpec.scala
@@ -27,8 +27,8 @@ class HilbertSpaceTimeKeyIndexSpec extends FunSpec with Matchers{
     }
 
 
-    it("generates hand indexes you can hand check 2x2x2"){
-     val hilbert = HilbertSpaceTimeKeyIndex(SpaceTimeKey(0,0,y2k), SpaceTimeKey(2,2,y2k.plusMillis(1)),1,1)
+    it("generates hand indexes you can hand check 3x3x2"){
+     val hilbert = HilbertSpaceTimeKeyIndex(SpaceTimeKey(0,0,y2k), SpaceTimeKey(2,2,y2k.plusMillis(1)),2,1)
      val idx = List[SpaceTimeKey](SpaceTimeKey(0,0,y2k), SpaceTimeKey(0,1,y2k),
                                   SpaceTimeKey(1,1,y2k), SpaceTimeKey(1,0,y2k),
                                   SpaceTimeKey(1,0,y2k.plusMillis(1)), SpaceTimeKey(1,1,y2k.plusMillis(1)),
@@ -40,11 +40,11 @@ class HilbertSpaceTimeKeyIndexSpec extends FunSpec with Matchers{
     }
 
     it("Generates a Seq[(Long,Long)] given a key range (SpatialKey,SpatialKey)"){
+      // See http://mathworld.wolfram.com/HilbertCurve.html for reference
       val t1 = y2k
       val t2 = y2k.plusMillis(1)
 
       //hand checked examples for a 2x2x2
-      // note: The col/row of the end key does not matter here, eh ?
       val hilbert = HilbertSpaceTimeKeyIndex(SpaceTimeKey(0,0,t1), SpaceTimeKey(1,1,t2), 1, 1)
 
       // select origin point only
@@ -60,23 +60,23 @@ class HilbertSpaceTimeKeyIndexSpec extends FunSpec with Matchers{
 
       // first 4 sub cubes (along y), front face
       idx = hilbert.indexRanges((SpaceTimeKey(0,0,t1), SpaceTimeKey(1,1,t1)))
-      idx.length should be (1)
-      idx.toSet should be (Set(0->3))
-
-      // second 4 sub cubes (along y), back face
-      idx = hilbert.indexRanges((SpaceTimeKey(0,0,t2), SpaceTimeKey(1,1,t2)))
-      idx.length should be (1)
-      idx.toSet should be (Set(4->7))
-
-      //4 sub cubes (along x), floor
-      idx = hilbert.indexRanges((SpaceTimeKey(0,0,t1), SpaceTimeKey(1,0,t2)))
       idx.length should be (3)
       idx.toSet should be (Set(0->0, 3->4, 7->7))
 
-      //next 4 sub cubes (along x)
-      idx = hilbert.indexRanges((SpaceTimeKey(0,1,t1), SpaceTimeKey(1,1,t2)))
+      // second 4 sub cubes (along y), back face
+      idx = hilbert.indexRanges((SpaceTimeKey(0,0,t2), SpaceTimeKey(1,1,t2)))
       idx.length should be (2)
       idx.toSet should be (Set(1->2, 5->6))
+
+      //4 sub cubes (along x), bottom face
+      idx = hilbert.indexRanges((SpaceTimeKey(0,0,t1), SpaceTimeKey(1,0,t2)))
+      idx.length should be (2)
+      idx.toSet should be (Set(0->1, 6->7))
+
+      //next 4 sub cubes (along x), top face
+      idx = hilbert.indexRanges((SpaceTimeKey(0,1,t1), SpaceTimeKey(1,1,t2)))
+      idx.length should be (1)
+      idx.toSet should be (Set(2->5))
     }
   }
 }

--- a/spark/src/test/scala/geotrellis/spark/testfiles/TestFiles.scala
+++ b/spark/src/test/scala/geotrellis/spark/testfiles/TestFiles.scala
@@ -125,7 +125,7 @@ trait TestFiles { self: TestEnvironment =>
     spaceTimeTestFile("spacetime-all-hundreds")
 
   /** Coordinates are CCC,RRR.TTT where C = column, R = row, T = time (year in 2010 + T).
-    * So 34,025.004 would represent col 34, row 25, year 2014
+    * So 34,025,004 would represent col 34, row 25, year 2014
     */
   lazy val CoordinateSpaceTime =
     spaceTimeTestFile("spacetime-coordinates")


### PR DESCRIPTION
This change set includes:
   * Addition of an `Option[KeyBounds[K]]` parameter to the layer writer `write` call.  This allows the user to write into a range different from that of the rdd so that they can update the empty space later.
   * Hilbert Curve Changes
      * The x- and y-dimensions had been transposed in the Hilbert Index creation code.  This was probably not detected earlier because the two dimensions are typically about the same size?
      * The calculation of the location on the Hilbert curve corresponding to a particular key has been adjusted.
      * A corner-case in the calculation of the number of bits required to represent numbers has been adjusted.
      * The Hilbert Index tests have been changed to be consistent with [this page](http://mathworld.wolfram.com/HilbertCurve.html).

All tests which pass in the base fork pass with these changes.